### PR TITLE
Add mcp_exclude_body_params() method to exclude parameters from MCP tool body schema

### DIFF
--- a/djangorestframework_mcp/schema.py
+++ b/djangorestframework_mcp/schema.py
@@ -576,7 +576,11 @@ def generate_body_schema(tool: MCPTool) -> Dict[str, Any]:
             excluded_params = []
 
         # Remove excluded parameters from the schema
-        if excluded_params and isinstance(body_schema, dict) and "properties" in body_schema:
+        if (
+            excluded_params
+            and isinstance(body_schema, dict)
+            and "properties" in body_schema
+        ):
             for param in excluded_params:
                 if param in body_schema["properties"]:
                     del body_schema["properties"][param]

--- a/djangorestframework_mcp/views.py
+++ b/djangorestframework_mcp/views.py
@@ -148,7 +148,7 @@ class MCPView(View):
             # Add structured content if result is JSON-serializable
             try:
                 # Test if result can be JSON serialized (for structuredContent validation)
-                json.dumps(result)
+                json.dumps(result, default=str)
                 response["structuredContent"] = result
             except (TypeError, ValueError):
                 # If result contains non-JSON-serializable data, skip structuredContent


### PR DESCRIPTION
Closes #15. Implements solution to support excluding parameters that come from sources other than the request body (authentication context, headers, etc.).

Changes:
- Added mcp_exclude_body_params() method support in generate_body_schema()
- Handles both string and list return values for excluded parameters
- Provides action context via self.action for conditional exclusions
- Removes excluded fields from both properties and required lists

Tests:
- Added 9 unit tests covering all edge cases (string/list return, None, action-specific)
- Added 5 integration tests for end-to-end functionality
- Tests verify schema generation, tool calls, and regression scenarios

Documentation:
- Added "Excluding Parameters from Request Body" section to README
- Includes examples for basic usage, action-specific exclusions, and mixins
- Documents all supported return value types

🤖 Generated with [Claude Code](https://claude.com/claude-code)