### PR TITLE
Release v0.1.0a4

### DIFF
--- a/djangorestframework_mcp/__init__.py
+++ b/djangorestframework_mcp/__init__.py
@@ -1,3 +1,3 @@
 """Django REST Framework MCP - Expose DRF APIs as MCP tools."""
 
-__version__ = "0.1.0a2"
+__version__ = "0.1.0a4"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", encoding="utf-8") as fh:
 
 setup(
     name="django-rest-framework-mcp",
-    version="0.1.0a3",
+    version="0.1.0a4",
     author="Django REST Framework MCP Contributors",
     description="Expose Django REST Framework APIs as MCP servers for LLMs",
     long_description=long_description,


### PR DESCRIPTION
## Summary
- Bump version to 0.1.0a4
- Released to PyPI: https://pypi.org/project/django-rest-framework-mcp/0.1.0a4/

## Changes Since v0.1.0a3
- Add Django 5+ support (#14)