### PR TITLE
feat: expose filter fields in list action tool schemas

### DIFF
--- a/djangorestframework_mcp/schema.py
+++ b/djangorestframework_mcp/schema.py
@@ -531,9 +531,134 @@ def field_to_json_schema(field: Field) -> Dict[str, Any]:
     return schema
 
 
+def generate_filter_schema(tool: MCPTool) -> Dict[str, Any]:
+    """
+    Generate a JSON schema for the filter fields of a list action.
+
+    Extracts filter fields from the ViewSet's filterset_class (django-filter)
+    and search/ordering fields from DRF filter backends, exposing them as
+    optional tool input parameters so LLMs can pass query filters.
+
+    Args:
+        tool: The MCPTool object containing all tool information.
+
+    Returns:
+        Dict containing filter schema and whether filters are required.
+    """
+    viewset_class = tool.viewset_class
+    properties: Dict[str, Any] = {}
+
+    # Extract filter fields from filterset_class (django-filter)
+    filterset_class = getattr(viewset_class, "filterset_class", None)
+    if filterset_class is not None:
+        try:
+            filterset = filterset_class()
+            for field_name, field in filterset.filters.items():
+                field_schema = _filter_field_to_schema(field_name, field)
+                if field_schema:
+                    properties[field_name] = field_schema
+        except Exception:
+            pass
+    else:
+        # Fall back to filterset_fields if no filterset_class
+        filterset_fields = getattr(viewset_class, "filterset_fields", None)
+        if filterset_fields:
+            for field_name in filterset_fields:
+                properties[field_name] = {
+                    "type": "string",
+                    "description": f"Filter by {field_name}",
+                }
+
+    # Extract search fields from SearchFilter backend
+    filter_backends = getattr(viewset_class, "filter_backends", [])
+    try:
+        from rest_framework.filters import SearchFilter, OrderingFilter
+
+        if any(issubclass(b, SearchFilter) for b in filter_backends):
+            search_fields = getattr(viewset_class, "search_fields", [])
+            if search_fields:
+                properties["search"] = {
+                    "type": "string",
+                    "description": f"Search across: {', '.join(str(f) for f in search_fields)}",
+                }
+
+        if any(issubclass(b, OrderingFilter) for b in filter_backends):
+            ordering_fields = getattr(viewset_class, "ordering_fields", [])
+            if ordering_fields:
+                properties["ordering"] = {
+                    "type": "string",
+                    "description": (
+                        f"Order by: {', '.join(str(f) for f in ordering_fields)}. "
+                        "Prefix with - for descending."
+                    ),
+                }
+    except ImportError:
+        pass
+
+    if not properties:
+        return {"schema": None, "is_required": False}
+
+    return {
+        "schema": {
+            "type": "object",
+            "properties": properties,
+            "required": [],
+        },
+        "is_required": False,
+    }
+
+
+def _filter_field_to_schema(field_name: str, field: Any) -> Dict[str, Any]:
+    """Convert a django-filter field to a JSON schema property."""
+    schema: Dict[str, Any] = {"type": "string"}
+
+    try:
+        from django_filters import (
+            BooleanFilter,
+            NumberFilter,
+            UUIDFilter,
+            BaseInFilter,
+            ChoiceFilter,
+        )
+
+        if isinstance(field, BooleanFilter):
+            schema = {"type": "boolean"}
+        elif isinstance(field, NumberFilter):
+            schema = {"type": "number"}
+        elif isinstance(field, UUIDFilter):
+            schema = {"type": "string"}
+        elif isinstance(field, BaseInFilter):
+            schema = {"type": "string", "description": f"Comma-separated values for {field_name}"}
+        elif isinstance(field, ChoiceFilter):
+            choices = list(field.extra.get("choices", []))
+            if choices:
+                enum_values = [str(c[0]) for c in choices if c[0]]
+                if enum_values:
+                    schema["enum"] = enum_values
+    except ImportError:
+        pass
+
+    # Use label or help_text if available
+    label = getattr(field, "label", None)
+    help_text = getattr(field.field, "help_text", None) if hasattr(field, "field") else None
+
+    if label:
+        schema["title"] = str(label)
+    if help_text:
+        schema["description"] = str(help_text)
+    elif "description" not in schema:
+        schema["description"] = f"Filter by {field_name}"
+
+    return schema
+
+
 def generate_body_schema(tool: MCPTool) -> Dict[str, Any]:
     """
     Generate the body schema for a ViewSet action.
+
+    For list actions, generates a filter schema from the ViewSet's filterset_class
+    and search/ordering backends. For create/update actions, generates a body schema
+    from the serializer class.
 
     Args:
         tool: The MCPTool object containing all tool information.
@@ -553,9 +678,13 @@ def generate_body_schema(tool: MCPTool) -> Dict[str, Any]:
 
     # Fall back to using view_class serializer if input_serializer not provided
     else:
-        # For list, retrieve, destroy actions where no custom input_serializer was provided, we don't expect input
-        if tool.action in ["list", "retrieve", "destroy"]:
+        # For retrieve, destroy actions where no custom input_serializer was provided, we don't expect input
+        if tool.action in ["retrieve", "destroy"]:
             return {"schema": None, "is_required": False}
+
+        # For list actions, generate filter schema instead of body schema
+        if tool.action == "list":
+            return generate_filter_schema(tool)
 
         instance = tool.viewset_class()
         instance.action = tool.action

--- a/djangorestframework_mcp/views.py
+++ b/djangorestframework_mcp/views.py
@@ -283,6 +283,12 @@ class MCPView(View):
         method_kwargs = params.get("kwargs", {})
         body_data = params.get("body", {})
 
+        # For list actions, body contains filter params that need to go into query params
+        query_params = {}
+        if action == "list" and body_data:
+            query_params = body_data
+            body_data = {}
+
         # Create a new HttpRequest that represents the equivalent API call
         body_bytes = json.dumps(body_data).encode("utf-8") if body_data else b"{}"
         request = HttpRequest()
@@ -294,6 +300,17 @@ class MCPView(View):
             request.user = original_request.user
         if hasattr(original_request, "auth"):
             request.auth = original_request.auth
+
+        # For list actions, inject filter params as query parameters so DRF's
+        # DjangoFilterBackend, SearchFilter, and OrderingFilter pick them up.
+        if query_params:
+            from django.http import QueryDict
+
+            qd = QueryDict(mutable=True)
+            for key, value in query_params.items():
+                if value is not None:
+                    qd[key] = str(value)
+            request.GET = qd
 
         # Replace the body with the body that was passed in via params
         request.META["HTTP_CONTENT_TYPE"] = "application/json"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -369,13 +369,14 @@ class TestGenerateToolSchema(unittest.TestCase):
         self.MockViewSet = MockViewSet
         self.MockSerializer = MockSerializer
 
-    def test_list_action_schema(self):
-        """Test schema generation for list action."""
+    def test_list_action_schema_no_filters(self):
+        """Test schema generation for list action without filters."""
         tool = MCPTool(name="list_test", viewset_class=self.MockViewSet, action="list")
         schema = generate_tool_schema(tool)
 
         input_schema = schema["inputSchema"]
         self.assertEqual(input_schema["type"], "object")
+        # No filterset_class on MockViewSet, so no body/filter properties
         self.assertEqual(input_schema["properties"], {})
         self.assertEqual(input_schema["required"], [])
 
@@ -2208,6 +2209,123 @@ class TestChoiceFieldSchemas(unittest.TestCase):
         self.assertEqual(schema["type"], "array")
         self.assertEqual(schema["items"]["type"], "string")
         self.assertEqual(schema["items"]["enum"], [])  # Empty enum in items
+
+
+class TestGenerateFilterSchema(unittest.TestCase):
+    """Test filter schema generation for list actions with filterset_class."""
+
+    def test_list_action_with_filterset_class(self):
+        """Test that list actions with filterset_class expose filter fields in the schema."""
+        try:
+            import django_filters
+        except ImportError:
+            self.skipTest("django-filter not installed")
+
+        from tests.models import Product
+
+        class ProductFilter(django_filters.FilterSet):
+            name = django_filters.CharFilter(lookup_expr="icontains")
+            in_stock = django_filters.BooleanFilter()
+            min_price = django_filters.NumberFilter(field_name="price", lookup_expr="gte")
+            category = django_filters.UUIDFilter()
+
+            class Meta:
+                model = Product
+                fields = []
+
+        class FilteredViewSet(ModelViewSet):
+            queryset = Product.objects.all()
+            serializer_class = serializers.Serializer
+            filterset_class = ProductFilter
+
+        tool = MCPTool(name="list_products", viewset_class=FilteredViewSet, action="list")
+        schema = generate_tool_schema(tool)
+
+        input_schema = schema["inputSchema"]
+        # Should have a "body" property containing the filter schema
+        self.assertIn("body", input_schema["properties"])
+
+        body = input_schema["properties"]["body"]
+        props = body["properties"]
+
+        # All filter fields should be present
+        self.assertIn("name", props)
+        self.assertIn("in_stock", props)
+        self.assertIn("min_price", props)
+        self.assertIn("category", props)
+
+        # Types should be correct
+        self.assertEqual(props["in_stock"]["type"], "boolean")
+        self.assertEqual(props["min_price"]["type"], "number")
+
+        # Filter params are never required
+        self.assertEqual(body["required"], [])
+
+        # body itself should not be required at top level
+        self.assertNotIn("body", input_schema["required"])
+
+    def test_list_action_with_filterset_fields(self):
+        """Test that list actions with filterset_fields expose filter fields."""
+        from tests.models import Product
+
+        class SimpleFilteredViewSet(ModelViewSet):
+            queryset = Product.objects.all()
+            serializer_class = serializers.Serializer
+            filterset_fields = ["name", "in_stock", "price"]
+
+        tool = MCPTool(name="list_products", viewset_class=SimpleFilteredViewSet, action="list")
+        schema = generate_tool_schema(tool)
+
+        input_schema = schema["inputSchema"]
+        self.assertIn("body", input_schema["properties"])
+
+        body = input_schema["properties"]["body"]
+        self.assertIn("name", body["properties"])
+        self.assertIn("in_stock", body["properties"])
+        self.assertIn("price", body["properties"])
+
+    def test_list_action_with_search_and_ordering(self):
+        """Test that search_fields and ordering_fields are exposed."""
+        from rest_framework.filters import SearchFilter, OrderingFilter
+        from tests.models import Product
+
+        class SearchableViewSet(ModelViewSet):
+            queryset = Product.objects.all()
+            serializer_class = serializers.Serializer
+            filterset_fields = ["in_stock"]
+            filter_backends = [SearchFilter, OrderingFilter]
+            search_fields = ["name", "description"]
+            ordering_fields = ["name", "price"]
+
+        tool = MCPTool(name="list_products", viewset_class=SearchableViewSet, action="list")
+        schema = generate_tool_schema(tool)
+
+        body = schema["inputSchema"]["properties"]["body"]
+        self.assertIn("search", body["properties"])
+        self.assertIn("ordering", body["properties"])
+        self.assertIn("name", body["properties"]["search"]["description"])
+        self.assertIn("price", body["properties"]["ordering"]["description"])
+
+    def test_create_action_not_affected(self):
+        """Test that create actions still use serializer schema, not filter schema."""
+        from tests.models import Product
+
+        class FilteredViewSet(ModelViewSet):
+            queryset = Product.objects.all()
+            serializer_class = serializers.Serializer
+            filterset_fields = ["name", "in_stock"]
+
+        tool = MCPTool(name="create_product", viewset_class=FilteredViewSet, action="create")
+        schema = generate_tool_schema(tool)
+
+        # Create action should use serializer, not filters
+        input_schema = schema["inputSchema"]
+        if "body" in input_schema["properties"]:
+            body = input_schema["properties"]["body"]
+            # Should NOT have filter fields like "in_stock" as a separate filter param
+            # (it would only be there if it's part of the serializer)
+            self.assertNotIn("search", body.get("properties", {}))
+            self.assertNotIn("ordering", body.get("properties", {}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

List actions on ViewSets with `filterset_class` or `filterset_fields` now generate MCP tool input schemas that include the filter parameters. This allows LLMs to pass query filters (e.g. `session`, `is_unfilled`, `position`) when calling list tools, instead of getting unfiltered results.

**Before:** `list_*` tools have empty `inputSchema` — the LLM has no way to know filter params exist, so it fetches all records unfiltered.

**After:** Filter fields from `filterset_class` (django-filter), `filterset_fields`, `search_fields`, and `ordering_fields` are extracted and exposed as optional tool input parameters with proper types.

## Changes

### Schema generation (`schema.py`)

- New `generate_filter_schema()` function that extracts filter fields from the ViewSet's `filterset_class` or `filterset_fields`
- Maps django-filter field types to JSON schema types (`BooleanFilter` → `boolean`, `NumberFilter` → `number`, `UUIDFilter` → `string`, etc.)
- Includes `search` and `ordering` params when `SearchFilter`/`OrderingFilter` backends are present
- `generate_body_schema()` now calls `generate_filter_schema()` for `list` actions instead of returning `None`

### Execution (`views.py`)

- For `list` actions, filter params from MCP `body` are injected into `request.GET` (`QueryDict`) so `DjangoFilterBackend`, `SearchFilter`, and `OrderingFilter` pick them up automatically

### Tests (`tests/test_schema.py`)

- `test_list_action_with_filterset_class` — verifies filter fields from a `FilterSet` class are exposed with correct types
- `test_list_action_with_filterset_fields` — verifies simple `filterset_fields` list works
- `test_list_action_with_search_and_ordering` — verifies `search_fields` and `ordering_fields` are included
- `test_create_action_not_affected` — verifies create/update actions still use serializer schema

## Backwards Compatibility

Fully backwards compatible:
- ViewSets without filters still generate empty input schemas (no change)
- Create/update/partial_update/destroy actions are not affected
- The `body` key is reused for filter params on list actions (same structure the LLM already sends)

## Motivation

Without this change, LLMs calling MCP list tools have no way to filter results. For example, a staffing app's `list_staffingslots` tool returns all slots across all sessions because the LLM can't see that a `session` filter exists. This causes incorrect counts and misleading data in AI-powered workflows.